### PR TITLE
Cleanup URLs to https where redirected from http.

### DIFF
--- a/2018-community-candidates.html
+++ b/2018-community-candidates.html
@@ -154,7 +154,7 @@
             (<a href="https://OpenNeuro.org">https://OpenNeuro.org</a> - formerly known as
             OpenfMRI). I have also been promoting ethical data sharing by
             providing ready to use text for participant content forms
-            (<a href="http://open-brain-consent.readthedocs.io/en/latest/ultimate.html">http://open-brain-consent.readthedocs.io/en/latest/ultimate.html</a>).
+            (<a href="https://open-brain-consent.readthedocs.io/en/latest/ultimate.html">http://open-brain-consent.readthedocs.io/en/latest/ultimate.html</a>).
             I would work with the Open Humans Foundation to help integrate it
             with existing open neuroimaging databases and getting their
             participants involved in additional follow-up data collection
@@ -162,7 +162,7 @@
           </p>
           <h4>Links</h4>
           <ul>
-            <li><a href="http://chrisgorgolewski.org">http://chrisgorgolewski.org</a></li>
+            <li><a href="https://chrisgorgolewski.org">http://chrisgorgolewski.org</a></li>
             <li><a href="https://twitter.com/ChrisFiloG">https://twitter.com/ChrisFiloG</a></li>
             <li><a href="https://github.com/chrisfilo">https://github.com/chrisfilo</a></li>
             <li><a href="https://www.openhumans.org/member/filo/">https://www.openhumans.org/member/filo/</a></li>
@@ -212,8 +212,8 @@
               of tools developed for working with OpenHumans data</a></li>
             <li><a href="https://diyps.org/2017/02/12/making-it-possible-for-researchers-to-work-with-openaps-or-general-nightscout-data-and-creating-a-complex-json-to-csv-command-line-tool-that-works-with-unknown-schema/">Why
               I’m building tools to work with OpenHumans</a></li>
-            <li>Dana's blog: <a href="http://www.DIYPS.org">http://www.DIYPS.org</a></li>
-            <li><a href="http://www.OpenAPS.org">Open Source Artificial
+            <li>Dana's blog: <a href="https://DIYPS.org">http://www.DIYPS.org</a></li>
+            <li><a href="https://OpenAPS.org">Open Source Artificial
               Pancreas System (OpenAPS) movement</a></li>
           </ul>
           <h4>Contributions to Open Humans</h4>
@@ -270,7 +270,7 @@
           </p>
           <h4>Links</h4>
           <ul>
-            <li><a href="http://www.drhydenotjekyll.com/">http://www.drhydenotjekyll.com/</a></li>
+            <li><a href="https://www.drhydenotjekyll.com/">http://www.drhydenotjekyll.com/</a></li>
             <li><a href="https://twitter.com/EmbrietteHyde">https://twitter.com/EmbrietteHyde</a></li>
             <li><a href="https://www.linkedin.com/in/embriettehyde/">https://www.linkedin.com/in/embriettehyde/</a></li>
           </ul>
@@ -327,7 +327,7 @@
           </p>
           <h4>Links</h4>
           <ul>
-            <li><a href="http://www.blackbear.biz">http://www.blackbear.biz</a></li>
+            <li><a href="https://www.blackbear.biz">http://www.blackbear.biz</a></li>
             <li><a href="https://twitter.com/blackbearnh">https://twitter.com/blackbearnh</a></li>
           </ul>
           <h4>Contributions to Open Humans</h4>
@@ -371,7 +371,7 @@
           </p>
           <h4>Links</h4>
           <ul>
-            <li><a href="http://www.qol.unige.ch">www.qol.unige.ch</a></li>
+            <li><a href="https://www.qol.unige.ch">www.qol.unige.ch</a></li>
             <li>Google Scholar <a href="http://j.mp/GoogleScholar_Wac">http://j.mp/GoogleScholar_Wac</a></li>
             <li>Youtube <a href="https://www.youtube.com/channel/UCohpE4xXEDXLc0T_lIcl-7g">https://www.youtube.com/channel/UCohpE4xXEDXLc0T_lIcl-7g</a></li>
             <li>LinkedIn <a href="https://www.linkedin.com/in/katarzynawac">https://www.linkedin.com/in/katarzynawac</a></li>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
               www.openhumans.org</a>
           </p>
           <div class="btn-group" role="group" aria-label="PGP Social Links">
-            <a class="btn btn-default" href="http://blog.openhumans.org">
+            <a class="btn btn-default" href="https://blog.openhumans.org">
               <i class="fa fa-pencil-square-o"></i> Blog</a>
             <a class="btn btn-default" href="https://twitter.com/OpenHumansOrg">
               <i class="fa fa-twitter"></i> @OpenHumansOrg</a>
@@ -79,7 +79,7 @@
                 href="https://www.facebook.com/openhumansorg/">
               <i class="fa fa-facebook-square"></i> Facebook</a>
             <a type="button" class="btn btn-default"
-                href="http://slackin.openhumans.org/">
+                href="https://slackin.openhumans.org/">
               <i class="fa fa-comments-o"></i> Slack chatroom</a>
           </div>
         </div>
@@ -122,7 +122,7 @@
         <hr style="margin-top: 10px; margin-bottom: 5px;">
         <div class="row">
           <div class="col-xs-8 col-sm-9 col-md-10">
-            <h4><a href="http://www.madpriceball.net/">Mad Ball</a></h4>
+            <h4><a href="https://www.madpriceball.net/">Mad Ball</a></h4>
             <div style="margin-left:20px">
               <div class="row">
                 <div class="col-xs-5 col-sm-3">
@@ -159,7 +159,7 @@
         <hr style="margin-top: 10px; margin-bottom: 5px;">
         <div class="row">
           <div class="col-xs-8 col-sm-9 col-md-10">
-            <h4><a href="http://ruleofthirds.de">Bastian Greshake Tzovaras</a></h4>
+            <h4><a href="https://tzovar.as/">Bastian Greshake Tzovaras</a></h4>
             <div style="margin-left:20px">
               <div class="row">
                 <div class="col-xs-5 col-sm-3">
@@ -232,7 +232,7 @@
         <hr style="margin-top: 10px; margin-bottom: 5px;">
         <div class="row">
           <div class="col-xs-8 col-sm-9 col-md-10">
-            <h4><a href="http://www.madpriceball.net/">Mad Ball</a><br><small>2017-2020 Seat</small></h4>
+            <h4><a href="https://www.madpriceball.net/">Mad Ball</a><br><small>2017-2020 Seat</small></h4>
             <div style="margin-left:20px">
               <div class="row">
                 <div class="col-xs-5 col-sm-3">


### PR DESCRIPTION
**Note: Before merging this pull request the Slack.OpenHumans Subdomain needs the certificate updated  - currently uses an expired LetsEncrypt cert.**

Commit details:
Note: In 2018 candidates html - updated urls, not display text where
http is used.

Changed Bastian's domain to https://tzorvar.as where the previous
domain ruleofthirds.de redirected.